### PR TITLE
Add support of K2 compiler and K2 mode of Idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+### Intelliji Platform ###
+.intellijPlatform

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,41 +1,24 @@
 plugins {
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "1.9.22"
-    id("org.jetbrains.intellij") version "1.17.2"
+    id("org.jetbrains.kotlin.jvm") version "2.0.21"
+    id("org.jetbrains.intellij.platform") version "2.1.0"
 }
 
 group = "com.vladuken.plugin"
-version = "0.3"
+version = "0.4"
 
 repositories {
     mavenCentral()
 }
 
-// Configure Gradle IntelliJ Plugin
-// Read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
-intellij {
-    version.set("2023.2.5")
-    type.set("IC") // Target IDE Platform
-
-    plugins.set(listOf("android", "java", "org.jetbrains.kotlin"))
-}
-
 tasks {
-    // Set the JVM compatibility versions
-    withType<JavaCompile> {
-        sourceCompatibility = "17"
-        targetCompatibility = "17"
-    }
-    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions.jvmTarget = "17"
-    }
     buildSearchableOptions {
         enabled = false
     }
 
     patchPluginXml {
-        sinceBuild.set("231")
-        untilBuild.set("242.*")
+        sinceBuild.set("242")
+        untilBuild.set("243.*")
     }
 
     signPlugin {
@@ -47,4 +30,24 @@ tasks {
     publishPlugin {
         token.set(System.getenv("PUBLISH_TOKEN"))
     }
+}
+
+repositories {
+    mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
+}
+
+dependencies {
+    intellijPlatform {
+        intellijIdeaCommunity("2024.2.1")
+        javaCompiler("21")
+        bundledPlugins("com.intellij.java", "org.jetbrains.kotlin")
+
+        pluginVerifier()
+        zipSigner()
+        instrumentationTools()
+    }
+
 }

--- a/src/main/kotlin/com/vladuken/plugin/mockkgenerator/parser/DomainInfoParser.kt
+++ b/src/main/kotlin/com/vladuken/plugin/mockkgenerator/parser/DomainInfoParser.kt
@@ -4,7 +4,6 @@ import com.vladuken.plugin.mockkgenerator.model.DomainClassInfo
 import com.vladuken.plugin.mockkgenerator.model.DomainConstructorParameters
 import org.jetbrains.kotlin.idea.base.psi.kotlinFqName
 import org.jetbrains.kotlin.idea.references.mainReference
-import org.jetbrains.kotlin.nj2k.types.typeFqName
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFunctionType
 import org.jetbrains.kotlin.psi.KtTypeReference
@@ -46,7 +45,7 @@ private fun KtClass.parseToDomainConstructorParameters(): List<DomainConstructor
         ?.valueParameters
         ?.map { ktParameter ->
             DomainConstructorParameters(
-                parameterTypeFqn = ktParameter.typeFqName().toString(),
+                parameterTypeFqn = ktParameter.typeReference?.kotlinFqName?.toString().orEmpty(),
                 parameterName = ktParameter.name.toString(),
                 rawTypeString = ktParameter.typeReference?.text.toString(),
                 nestedGenericTypeName = when (val typeElement = ktParameter.typeReference?.typeElement) {

--- a/src/main/kotlin/com/vladuken/plugin/mockkgenerator/parser/GeneratorFieldsMapper.kt
+++ b/src/main/kotlin/com/vladuken/plugin/mockkgenerator/parser/GeneratorFieldsMapper.kt
@@ -64,7 +64,6 @@ private fun DomainClassInfo.toImports(): Set<String> {
     return buildSet {
         add(fqClassName)
         parameters.forEach { parameter ->
-            add(parameter.parameterTypeFqn)
             addAll(parameter.nestedGenericTypesFqn)
         }
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -38,6 +38,9 @@
                              implementation="com.vladuken.plugin.mockkgenerator.template.context.KotlinTestTemplateContextType$ObjectDeclaration"/>
 
     </extensions>
+    <extensions defaultExtensionNs="org.jetbrains.kotlin">
+        <supportsKotlinPluginMode supportsK2="true" />
+    </extensions>
     <actions>
         <group
                 id="MockKGeneratorGroup"


### PR DESCRIPTION
K2 Mode in Intellij Idea requires a plugin to declare explicit support of the K2 compiler. This might be done only after migration to Inetllij Idea Plugin v2, which is now `org.jetbrains.intellij.platform` (and `org.jetbrains.intellij` is now discontinued).

The migration documentation is here: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-migration.html